### PR TITLE
feat: generate mnenomic phrase

### DIFF
--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -1,8 +1,11 @@
 'use client'
+
 import { useCallback, useEffect, useState } from 'react'
 
+import { hexToBytes } from '@noble/hashes/utils'
 import { useRouter } from 'next/navigation'
-import { generateSecretKey, getPublicKey } from 'nostr-tools'
+import { getPublicKey } from 'nostr-tools'
+import { generateSeedWords, privateKeyFromSeedWords } from 'nostr-tools/nip06'
 import { npubEncode, nsecEncode } from 'nostr-tools/nip19'
 import { useDispatch } from 'react-redux'
 
@@ -12,10 +15,14 @@ import LobstrLogo from '@/components/LobstrLogo'
 import { login } from '@/redux/features/user'
 import { useAppSelector } from '@/redux/store'
 
+type Keys = {
+  nsec: string
+  npub: string
+  seedPhrase: string
+}
+
 const SignUp = () => {
-  const [keys, setKeys] = useState<Record<string, string | Uint8Array> | null>(
-    null,
-  )
+  const [keys, setKeys] = useState<Keys | null>(null)
 
   const userNpub = useAppSelector(({ user }) => user.publickey)
 
@@ -23,16 +30,24 @@ const SignUp = () => {
   const router = useRouter()
 
   const generateNostrKeys = useCallback(() => {
-    const secret = generateSecretKey()
-    const pubKey = getPublicKey(secret)
+    const seedPhrase = generateSeedWords()
 
-    const nsec = nsecEncode(secret)
+    const secret = privateKeyFromSeedWords(seedPhrase)
+    const encodedSecret = hexToBytes(secret)
+
+    const pubKey = getPublicKey(encodedSecret)
+
+    const nsec = nsecEncode(encodedSecret)
     const npub = npubEncode(pubKey)
 
-    setKeys({ nsec, npub })
-
+    setKeys({ nsec, npub, seedPhrase })
     dispatch(login(pubKey))
   }, [dispatch])
+
+  const seedPhraseSplit = keys?.seedPhrase.split(' ')
+  const transformCaption = (word: string, index: number) => {
+    return `${index + 1}. ${word}`
+  }
 
   useEffect(() => {
     if (userNpub) router.push('/dashboard')
@@ -47,16 +62,23 @@ const SignUp = () => {
         <div className="flex flex-col w-full h-full py-10 items-center ">
           <LobstrLogo size={200} />
         </div>
-        <div className="item-center flex flex-col gap-2 align-middle w-full px-10">
-          <h1 className="text-2xl  font-semibold text-center font-heading text-primary-500 mb-10">
-            Save your keys somewhere safe
+        <div className="item-center flex flex-col gap-10 align-middle w-full px-10">
+          <h1 className="text-2xl  font-semibold text-center font-heading text-primary-500">
+            Write down your seed phrase somewhere safe
           </h1>
-          <p className="text-center bg-gray-100 rounded-md text-black align-center">
-            {keys?.npub.slice(0, 30)}....
-          </p>
-          <p className="text-center bg-gray-100 rounded-md text-black align-center">
-            {keys?.nsec.slice(0, 30)}....
-          </p>
+
+          <div className="flex flex-row flex-wrap gap-2 justify-center">
+            {seedPhraseSplit?.map((word, index) => {
+              return (
+                <p
+                  className="text-black bg-gray-200 px-3 rounded-sm"
+                  key={index}
+                >
+                  {transformCaption(word, index)}
+                </p>
+              )
+            })}
+          </div>
           <Button variant="primary" onClick={() => router.push('/dashboard')}>
             Continue
           </Button>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:watch": "jest --watchAll"
   },
   "dependencies": {
+    "@noble/hashes": "^1.3.3",
     "@nostr-dev-kit/ndk": "^2.3.0",
     "@radix-ui/react-toast": "^1.1.5",
     "@reduxjs/toolkit": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -718,7 +718,7 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
   integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
 
-"@noble/hashes@^1.3.1", "@noble/hashes@~1.3.0", "@noble/hashes@~1.3.1":
+"@noble/hashes@^1.3.1", "@noble/hashes@^1.3.3", "@noble/hashes@~1.3.0", "@noble/hashes@~1.3.1":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
   integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==


### PR DESCRIPTION
This PR had the objective of generating a 12-word seed phrase that can recover a key pair if needed.

What changed:

- Library added called Noble for hashing
- Generate a mnenomic phrase before then matching key pairs to it
- On create account flow, we now ask the user to write down their seed phrase

Next plans: key pairs will be retrievable inside settings